### PR TITLE
Update for Django 1.10 compatibility and repackage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea/
 *.egg-info
 .coverage
+/htmlcov
+/.tox

--- a/net_promoter_score/__init__.py
+++ b/net_promoter_score/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Django app for managing Net Promoter Score data.
 
 The NPS is a measure of customer loyalty that is measured by asking your
@@ -28,19 +27,3 @@ each score is timestamped and linked to a Django User object, so you can
 easily work out the time elapsed since the last time they were asked.
 
 """
-from net_promoter_score import settings
-
-
-def show_nps(request):
-    """Return True if the NPS survey should be shown to the request user.
-
-    This is a dynamic function that uses the request object to determine
-    whether to display the survey. It defaults to a basic function that
-    looks up the last time the user was shown the survey, so that each
-    user is only shown it every X days. This should be overridden in the
-    Django settings to provide more sophisticated analysis - users with
-    different profiles may be surveyed more/less frequently, and you may
-    wish to survery based on previous answers.
-
-    """
-    return settings.NPS_DISPLAY_FUNCTION(request)

--- a/net_promoter_score/middleware.py
+++ b/net_promoter_score/middleware.py
@@ -7,7 +7,7 @@ on each request. This value is added to the user session (so a max
 of one lookup per session.
 
 """
-from net_promoter_score import show_nps
+from net_promoter_score.utils import show_nps
 
 
 class NPSMiddleware(object):

--- a/net_promoter_score/tests/test_functions.py
+++ b/net_promoter_score/tests/test_functions.py
@@ -5,7 +5,7 @@ import mock
 from django.contrib.auth import get_user_model
 from django.test import TransactionTestCase, RequestFactory
 
-from net_promoter_score import show_nps
+from net_promoter_score.utils import show_nps
 from net_promoter_score.models import UserScore
 from net_promoter_score.settings import default_display_function, NPS_DISPLAY_INTERVAL
 

--- a/net_promoter_score/urls.py
+++ b/net_promoter_score/urls.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    'net_promoter_score.views',
-    url(r'^score/$', 'post_score', name="post_score"),
-)
+from net_promoter_score import views
+
+urlpatterns = [
+    url(
+        r'^score/$',
+        views.post_score,
+        name="post_score"
+    ),
+]

--- a/net_promoter_score/utils.py
+++ b/net_promoter_score/utils.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from net_promoter_score import settings
+
+
+def show_nps(request):
+    """Return True if the NPS survey should be shown to the request user.
+
+    This is a dynamic function that uses the request object to determine
+    whether to display the survey. It defaults to a basic function that
+    looks up the last time the user was shown the survey, so that each
+    user is only shown it every X days. This should be overridden in the
+    Django settings to provide more sophisticated analysis - users with
+    different profiles may be surveyed more/less frequently, and you may
+    wish to survery based on previous answers.
+
+    """
+    return settings.NPS_DISPLAY_FUNCTION(request)

--- a/requirements/django110.txt
+++ b/requirements/django110.txt
@@ -1,0 +1,2 @@
+-r base.txt
+Django==1.10

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-nps",
-    version="0.2.4-dev",
+    version="0.3.0",
     packages=find_packages(),
     install_requires=['Django>=1.8'],
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = django18_py27
+envlist = django18_py27, django19_py27, django110_py27
+# Python 3 support is not quite there yet. Contributions welcome
 
 [testenv]
 basepython = python2.7
@@ -17,3 +18,10 @@ deps = -rrequirements/django19.txt
 [testenv:django19_py35]
 basepython = python3.5
 deps = -rrequirements/django19.txt
+
+[testenv:django110_py27]
+deps = -rrequirements/django110.txt
+
+[testenv:django110_py35]
+basepython = python3.5
+deps = -rrequirements/django110.txt

--- a/urls.py
+++ b/urls.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.contrib import admin  # , staticfiles
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^nps/', include('net_promoter_score.urls',
         namespace="net_promoter_score")),
     # url(r'^static/(?P<path>.*)$', staticfiles.views.serve),
-)
+]


### PR DESCRIPTION
This changeset updates django-nps so that it should work with Django 1.10

Add tox config for Django 1.10
- Move imports out of package `__init__` to deal with `django.core.exceptions.AppRegistryNotReady` - created a new `utils` module to hold that function
- Fix up URLConf to be new format (list, with no prefix string)
- Update .gitignore
- Bump version to 0.3.0
