### PR TITLE
Enable usage with Django 1.10's MIDDLEWARE setting

### DIFF
--- a/net_promoter_score/middleware.py
+++ b/net_promoter_score/middleware.py
@@ -7,10 +7,17 @@ on each request. This value is added to the user session (so a max
 of one lookup per session.
 
 """
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Fallback for Django < 1.10
+    MiddlewareMixin = object
+
+
 from net_promoter_score.utils import show_nps
 
 
-class NPSMiddleware(object):
+class NPSMiddleware(MiddlewareMixin):
 
     """Add show_nps attr to the user session."""
 

--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+from distutils.version import StrictVersion
+
+import django
+
+DJANGO_VERSION = StrictVersion(django.get_version())
+
 DEBUG = True
 
 DATABASES = {
@@ -18,13 +24,18 @@ INSTALLED_APPS = (
     'net_promoter_score',
 )
 
-MIDDLEWARE_CLASSES = [
+_MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 ]
+
+if DJANGO_VERSION < StrictVersion('1.10.0'):
+    MIDDLEWARE_CLASSES = _MIDDLEWARE_CLASSES
+else:
+    MIDDLEWARE = _MIDDLEWARE_CLASSES
 
 SECRET_KEY = "NPS"
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     mock==2.0
     django18_py27: Django>1.7,<1.9
     django19_py27: Django>1.9,<1.10
-    django110_py27: Django>1.9,<1.11
+    django110_py27: Django>1.10,<1.11
 
 commands=
     coverage erase


### PR DESCRIPTION
While the package was tested under 1.10, it was not tested using the new MIDDLEWARE
setting but instead the old MIDDLEWARE_CLASSES setting.

This PR does two things:

a) forces us to use the new MIDDLEWARE setting during testing under Django 1.10 and above.

b) utilises Django's MiddlewareMixin so that our Middleware can perform across versions.

Down the line, when MIDDLEWARE_CLASSES is official deprecated we will have to migrate
our middleware to the new format. Until then, this will have to be our solution if we
are to support old versions.