### PR TITLE
Make migrations python3 friendly

### DIFF
--- a/net_promoter_score/migrations/0001_initial.py
+++ b/net_promoter_score/migrations/0001_initial.py
@@ -17,9 +17,9 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('timestamp', models.DateTimeField()),
-                ('score', models.IntegerField(default=-1, help_text=b'0-6=Detractor; 7-8=Neutral; 9-10=Promoter', db_index=True)),
-                ('reason', models.TextField(help_text=b'Reason for the score', blank=True)),
-                ('group', models.CharField(default=b'unknown', help_text='Detractor, neutral or promoter.', max_length=10, db_index=True, choices=[(b'unknown', b'No answer'), (b'detractor', b'Detractor (0-6)'), (b'neutral', b'Neutral (7-8)'), (b'promoter', b'Promoter (9-10)')])),
+                ('score', models.IntegerField(default=-1, help_text='0-6=Detractor; 7-8=Neutral; 9-10=Promoter', db_index=True)),
+                ('reason', models.TextField(help_text='Reason for the score', blank=True)),
+                ('group', models.CharField(default='unknown', help_text='Detractor, neutral or promoter.', max_length=10, db_index=True, choices=[('unknown', 'No answer'), ('detractor', 'Detractor (0-6)'), ('neutral', 'Neutral (7-8)'), ('promoter', 'Promoter (9-10)')])),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
         ),

--- a/net_promoter_score/migrations/0002_promoterscore_source.py
+++ b/net_promoter_score/migrations/0002_promoterscore_source.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='userscore',
             name='source',
-            field=models.CharField(help_text=b"Source of user score, used for filtering results, e.g. 'app', 'web', 'email'.", max_length=20, blank=True),
+            field=models.CharField(help_text="Source of user score, used for filtering results, e.g. 'app', 'web', 'email'.", max_length=20, blank=True),
         ),
     ]

--- a/net_promoter_score/models.py
+++ b/net_promoter_score/models.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from django.db import models
 from django.conf import settings
 from django.utils.timezone import now as tz_now

--- a/net_promoter_score/tests/test_migrations.py
+++ b/net_promoter_score/tests/test_migrations.py
@@ -1,0 +1,24 @@
+from __future__ import unicode_literals
+
+from django.apps import apps
+from django.db import connection
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.state import ProjectState
+from django.test import TestCase
+
+
+class MigrationsTests(TestCase):
+
+    def test_for_missing_migrations(self):
+        """Checks if there're models changes which aren't reflected in migrations."""
+        migrations_loader = MigrationExecutor(connection).loader
+        migrations_detector = MigrationAutodetector(
+            from_state=migrations_loader.project_state(),
+            to_state=ProjectState.from_apps(apps)
+        )
+        if migrations_detector.changes(graph=migrations_loader.graph):
+            self.fail(
+                'Your models have changes that are not yet reflected '
+                'in a migration. You should add them now.'
+            )


### PR DESCRIPTION
Under python3 `makemigrations` complains that `net_promoter_score` has
changes in models which are not reflected in its migrations.

It's caused by b'' strings.