### PR TITLE
Django 5.2 updates

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,97 +1,87 @@
 name: Python / Django
 
 on:
-  push:
-    branches:
-      - master
+    push:
+        branches:
+            - master
 
-  pull_request:
-    types: [opened, synchronize, reopened]
+    pull_request:
+        types: [opened, synchronize, reopened]
 
 jobs:
-  format:
-    name: Check formatting
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toxenv: [fmt, lint, mypy]
-    env:
-      TOXENV: ${{ matrix.toxenv }}
+    format:
+        name: Check formatting
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                toxenv: [fmt, lint, mypy]
+        env:
+            TOXENV: ${{ matrix.toxenv }}
 
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Check out the repository
+              uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
+            - name: Set up Python (3.11)
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.11"
 
-      - name: Install and run tox
-        run: |
-          pip install tox
-          tox
+            - name: Install and run tox
+              run: |
+                  pip install tox
+                  tox
 
-  checks:
-    name: Run Django checks
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toxenv: ["django-checks"]
-    env:
-      TOXENV: ${{ matrix.toxenv }}
+    checks:
+        name: Run Django checks
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                toxenv: ["django-checks"]
+        env:
+            TOXENV: ${{ matrix.toxenv }}
 
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Check out the repository
+              uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
+            - name: Set up Python (3.11)
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.11"
 
-      - name: Install and run tox
-        run: |
-          pip install tox
-          tox
+            - name: Install and run tox
+              run: |
+                  pip install tox
+                  tox
 
-  test:
-    name: Run tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
-        exclude:
-          - python: "3.8"
-            django: "50"
-          - python: "3.8"
-            django: "main"
-          - python: "3.9"
-            django: "50"
-          - python: "3.9"
-            django: "main"
-          - python: "3.10"
-            django: "main"
-          - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
+    test:
+        name: Run tests
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python: ["3.10", "3.11", "3.12"]
+                # build LTS version, latest stable versions, HEAD
+                django: ["42", "50", "51", "52", "main"]
+                exclude:
+                    - python: "3.10"
+                      django: "main"
+                    - python: "3.11"
+                      django: "main"
 
-    env:
-      TOXENV: django${{ matrix.django }}-py${{ matrix.python }}
+        env:
+            TOXENV: django${{ matrix.django }}-py${{ matrix.python }}
 
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Check out the repository
+              uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
+            - name: Set up Python ${{ matrix.python }}
+              uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python }}
 
-      - name: Install and run tox
-        run: |
-          pip install tox
-          tox
+            - name: Install and run tox
+              run: |
+                  pip install tox
+                  tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,4 @@
 repos:
-  # python code formatting - will amend files
-  - repo: https://github.com/ambv/black
-    rev: 23.10.1
-    hooks:
-      - id: black
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
     rev: "v0.1.5"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,6 @@
 line-length = 88
+
+[lint]
 ignore = [
     "D100",  # Missing docstring in public module
     "D101",  # Missing docstring in public class
@@ -34,13 +36,13 @@ select = [
     "W",  # pycodestype (warnings)
 ]
 
-[isort]
+[lint.isort]
 combine-as-imports = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 8
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "*tests/*" = [
     "D205",  # 1 blank line required between summary line and description
     "D400",  # First line should end with a period

--- a/README
+++ b/README
@@ -4,20 +4,19 @@ Django app supporting Net Promoter Score (NPS) surveys
 
 ## Compatibility
 
-This package support Django 3.2+, Python 3.8+.
+This package supports Django 4.2+, Python 3.10+.
 
 ## Background - Net Promoter Score
 
-The NPS is a measure of customer loyalty that is captured by asking your
-customers a singe question:
+The NPS is a measure of customer loyalty that is captured by asking your customers a single
+question:
 
-> How likely is it that you would recommend our
-> [company|product|service] to a friend or colleague?"
+> How likely is it that you would recommend our [company|product|service] to a friend or colleague?"
 
-The answer to this question is a number from 0-10 (inclusive). These scores
-are then broken out into three distinct groups: 'detractors' (0-6), 'neutral'
-(7-8) and 'promoters' (9-10). The NPS is then the difference between the
-number of promoters and detractors (as a percentage of the whole population).
+The answer to this question is a number from 0-10 (inclusive). These scores are then broken out into
+three distinct groups: 'detractors' (0-6), 'neutral' (7-8) and 'promoters' (9-10). The NPS is then
+the difference between the number of promoters and detractors (as a percentage of the whole
+population).
 
 For example, if you ask 100 people, and you get the following results:
 
@@ -27,25 +26,22 @@ neutrals:   10%
 promoters:  70%
 ```
 
-Then your NPS is 70 - 20 = 50. *(NPS is expressed as a number, not a %)*
+Then your NPS is 70 - 20 = 50. _(NPS is expressed as a number, not a %)_
 
-NPS was orginally developed at the strategy consultants Bain & Company
-by Fred Reichheld in 2003. They retain the registered trademark for NPS,
-and you can read all about the history of it on their site "[Net Promoter System](http://netpromotersystem.com/about/index.aspx)".
+NPS was originally developed at the strategy consultants Bain & Company by Fred Reichheld in 2003.
+They retain the registered trademark for NPS, and you can read all about the history of it on their
+site "[Net Promoter System](http://netpromotersystem.com/about/index.aspx)".
 
 ## Usage
 
-This app is used to store the individual scores, and calculate the NPS
-based on these. It does not contain any templates for displaying the
-question itself, neither does it put any restriction around how often
-you ask the question, or to whom. It is up to the app developer to
-determine how this should work - each score is timestamped and linked to
-a Django User object, so you can easily work out the time elapsed since
-the last time they were asked.
+This app is used to store the individual scores, and calculate the NPS based on these. It does not
+contain any templates for displaying the question itself, neither does it put any restriction around
+how often you ask the question, or to whom. It is up to the app developer to determine how this
+should work - each score is timestamped and linked to a Django User object, so you can easily work
+out the time elapsed since the last time they were asked.
 
-For example, if you want to ensure that you only survey users every X days,
-you can add a context property to the template using the `display_to_user`
-method:
+For example, if you want to ensure that you only survey users every X days, you can add a context
+property to the template using the `display_to_user` method:
 
 ```python
 >>> # only show the survey every 90 days
@@ -53,16 +49,14 @@ method:
 True
 ```
 
-If you then show the survey - the output of which is a single value (the
-score) together with an optional reason ("what is the main reason for
-your score"), is then posted to the ``post_score`` endpoint, which
-registers the user score.
+If you then show the survey - the output of which is a single value (the score) together with an
+optional reason ("what is the main reason for your score"), is then posted to the `post_score`
+endpoint, which registers the user score.
 
-The NPS value itself can be calculated on any queryset of ``UserScore``
-objects - which allows you to track the score based on any attribute of
-the score itself or the underlying user. For instance, if you have
-custom user profiles, you may wish to segement your NPS by
-characteristics of those profiles.
+The NPS value itself can be calculated on any queryset of `UserScore` objects - which allows you to
+track the score based on any attribute of the score itself or the underlying user. For instance, if
+you have custom user profiles, you may wish to segment your NPS by characteristics of those
+profiles.
 
 ```python
 >>> # December's NPS
@@ -70,8 +64,8 @@ characteristics of those profiles.
 50
 ```
 
-The `post_score` endpoint returns a `JsonResponse` which contains a
-`'success': True|False` value together with the `UserScore` details:
+The `post_score` endpoint returns a `JsonResponse` which contains a `'success': True|False` value
+together with the `UserScore` details:
 
 ```python
 {
@@ -79,8 +73,9 @@ The `post_score` endpoint returns a `JsonResponse` which contains a
     "score": {"id": 1, "user": 1, "score": 0, "group": "detractor"}
 }
 ```
-If the score was rejected, the errors are returned in place of the score (errors
-are a list of lists, as returned from the Django `Form.errors` property):
+
+If the score was rejected, the errors are returned in place of the score (errors are a list of
+lists, as returned from the Django `Form.errors` property):
 
 ```python
 {
@@ -89,9 +84,8 @@ are a list of lists, as returned from the Django `Form.errors` property):
 }
 ```
 
-The app contains a piece of middleware, `NPSMiddleware`, which will add an
-attribute to the `HttpRequest` object called `show_nps`. If you add the
-middleware to your settings:
+The app contains a piece of middleware, `NPSMiddleware`, which will add an attribute to the
+`HttpRequest` object called `show_nps`. If you add the middleware to your settings:
 
 ```python
 # settings.py
@@ -110,7 +104,7 @@ You can then use this value in your templates:
 ```html
 <!-- show_nps template = {{request.show_nps}} -->
 {% if request.show_nps %}
-    <div>HTML goes here</div>
+<div>HTML goes here</div>
 {% endif %}
 ```
 
@@ -118,25 +112,23 @@ You can then use this value in your templates:
 
 **NPS_DISPLAY_INTERVAL**
 
-The number of days between surveys, integer, defaults to 30. This value is used
-by the default `show_nps` function to determine whether someone should be shown
-the survey.
+The number of days between surveys, integer, defaults to 30. This value is used by the default
+`show_nps` function to determine whether someone should be shown the survey.
 
 **NPS_DISPLAY_FUNCTION**
 
-A function that takes an `HttpRequest` object as its only argument, and which
-returns True if you want to show the survey. This function is used by the
-`net_promoter_score.show_nps` function. It defaults to return True if the
-request user has either never seen the survey, or hasn't seen it for more days
-than the `NPS_DISPLAY_INTERVAL`.
+A function that takes an `HttpRequest` object as its only argument, and which returns True if you
+want to show the survey. This function is used by the `net_promoter_score.show_nps` function. It
+defaults to return True if the request user has either never seen the survey, or hasn't seen it for
+more days than the `NPS_DISPLAY_INTERVAL`.
 
-This function should be overridden if you want fine-grained control over
-the process - it's the main hook into the app.
+This function should be overridden if you want fine-grained control over the process - it's the main
+hook into the app.
 
 ## Tests
 
-There is a full suite of tests for the app, which are best run through `tox`. If
-you wish to run the tests outside of tox, you should install the requirements first:
+There is a full suite of tests for the app, which are best run through `tox`. If you wish to run the
+tests outside of tox, you should install the requirements first:
 
 ```
 $ pip install -r requirements.txt
@@ -159,7 +151,8 @@ Please take care to follow the coding style - and PEP8.
 
 ## Acknowledgements
 
-Credit is due to **epantry** for the [original project](https://github.com/epantry/django-netpromoterscore) from which this was forked.
+Credit is due to **epantry** for the
+[original project](https://github.com/epantry/django-netpromoterscore) from which this was forked.
 
-Thanks also to the kind people at **Eldarion** ([website](http://eldarion.com/))
-for releasing the PyPI package name.
+Thanks also to the kind people at **Eldarion** ([website](http://eldarion.com/)) for releasing the
+PyPI package name.

--- a/net_promoter_score/middleware.py
+++ b/net_promoter_score/middleware.py
@@ -7,6 +7,7 @@ on each request. This value is added to the user session (so a max
 of one lookup per session.
 
 """
+
 from __future__ import annotations
 
 from typing import Callable

--- a/net_promoter_score/settings.py
+++ b/net_promoter_score/settings.py
@@ -4,6 +4,7 @@ Default settings for net_promoter_score.
 Override these settings in the Django settings if required.
 
 """
+
 from __future__ import annotations
 
 from django.conf import settings

--- a/net_promoter_score/views.py
+++ b/net_promoter_score/views.py
@@ -33,9 +33,7 @@ def post_score(request: HttpRequest) -> JsonResponse:
     form = UserScoreForm(request.POST, user=request.user)
     if form.is_valid():
         score = form.save()
-        return JsonResponse(
-            {"success": True, "score": score.json()}, status=201
-        )  # noqa
+        return JsonResponse({"success": True, "score": score.json()}, status=201)  # noqa
     else:
         errors = [(k, v[0]) for k, v in list(form.errors.items())]
         return JsonResponse({"success": False, "errors": errors}, status=422)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ python = "^3.10"
 django = "^4.2 || ^5.0"
 
 [tool.poetry.group.dev.dependencies]
-black = "*"
 coverage = "*"
 mypy = "*"
 pre-commit = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-nps"
-version = "1.1"
+version = "1.2"
 description = "Django app supporting Net Promoter Score (NPS) surveys."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -10,15 +10,12 @@ homepage = "https://github.com/yunojuno/django-nps"
 repository = "https://github.com/yunojuno/django-nps"
 classifiers = [
     "Environment :: Web Environment",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -26,10 +23,10 @@ classifiers = [
 packages = [{ include = "net_promoter_score" }]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-django = "^3.2 || ^4.0 || ^5.0"
+python = "^3.10"
+django = "^4.2 || ^5.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "*"
 coverage = "*"
 mypy = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,12 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{38,39,310}
-    django40-py{38,39,310}
-    django41-py{38,39,310,311}
-    django42-py{38,39,310,311}
+    ; https://docs.djangoproject.com/en/5.2/releases/
+    django42-py{310,311,312}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    django51-py{310,311,312}
+    django52-py{310,311,312}
+    djangomain-py312
 
 [testenv]
 deps =
@@ -17,11 +16,10 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
@@ -48,7 +46,7 @@ deps =
     ruff
 
 commands =
-    ruff net_promoter_score
+    ruff check net_promoter_score
 
 [testenv:mypy]
 description = Python source code type hints (mypy)

--- a/tox.ini
+++ b/tox.ini
@@ -33,12 +33,12 @@ commands =
     python manage.py makemigrations --dry-run --check --verbosity 3
 
 [testenv:fmt]
-description = Python source code formatting (black)
+description = Python source code formatting (ruff)
 deps =
-    black
+    ruff
 
 commands =
-    black --check net_promoter_score
+    ruff format --check net_promoter_score
 
 [testenv:lint]
 description = Python source code linting (ruff)


### PR DESCRIPTION

# Django 5.2 Compatibility Update

This PR introduces Django 5.2 compatibility while modernizing the project's testing infrastructure and development tools.

## 🚀 **Key Changes**

### **Django & Python Version Support**
- **Added support for:** Django 5.1 and 5.2
- **Removed support for:** Django 3.2, 4.0, 4.1 (now requires Django 4.2+)
- **Updated Python requirements:** Now requires Python 3.10+ (removed 3.8, 3.9 support)
- **Version bump:** Project version updated from 1.1 → 1.2

### **Testing Infrastructure Updates**
- **Updated `tox.ini`:**
  - Added Django 5.1 and 5.2 test environments
  - Removed deprecated Django versions (3.2, 4.0, 4.1)
  - Updated Python version matrix to 3.10-3.12 only
  - **Fixed ruff command:** Updated from `ruff net_promoter_score` to `ruff check net_promoter_score`
  - **Restricted Django main branch testing:** Now only runs on Python 3.12 (as requested)

- **Updated GitHub Actions workflow (`.github/workflows/tox.yml`):**
  - Updated Python version matrix: `["3.10", "3.11", "3.12"]`
  - Updated Django version matrix: `["42", "50", "51", "52", "main"]`
  - **Django main branch constraint:** Only tests on Python 3.12 (no pre-3.12 versions)

### **Development Tool Modernization**
- **Updated `pyproject.toml`:**
  - Modernized Poetry configuration: `[tool.poetry.dev-dependencies]` → `[tool.poetry.group.dev.dependencies]`
  - Updated Django version constraint: `^4.2 || ^5.0`
  - Updated Python version constraint: `^3.10`
  - Added Django 5.1 and 5.2 classifiers

- **Updated `.ruff.toml`:**
  - Modernized Ruff configuration format
  - Moved settings under `[lint]` section as per current Ruff standards
  - Updated section names: `[isort]` → `[lint.isort]`, `[mccabe]` → `[lint.mccabe]`, etc.

### **Documentation Updates**
- **Updated `README`:** Compatibility section now states "Django 4.2+, Python 3.10+"

## 🧹 **Code Quality**
- **Ran ruff check:** All linting checks pass ✅
- **Modern type hints:** Codebase already uses modern type annotations with `from __future__ import annotations`
- **Import organization:** All imports are properly sorted and organized

## 🔧 **Breaking Changes**
- **Minimum Django version:** Now requires Django 4.2+
- **Minimum Python version:** Now requires Python 3.10+

## 📝 **Migration Notes**
- Projects using this package with Django < 4.2 or Python < 3.10 will need to upgrade their environments
- The deprecated Django versions (3.2, 4.0, 4.1) are no longer tested or officially supported
- All development commands now use modern syntax (`ruff check` instead of `ruff`)

## ✅ **Testing**
- All existing tests continue to pass
- New Django versions (5.1, 5.2) are now included in the test matrix
- GitHub Actions workflow updated to reflect new version support matrix